### PR TITLE
Removed unsafe attempt to read incident_case_id when downloading inci…

### DIFF
--- a/app/src/main/java/org/unicef/rapidreg/sync/GBVSyncPresenter.java
+++ b/app/src/main/java/org/unicef/rapidreg/sync/GBVSyncPresenter.java
@@ -349,7 +349,6 @@ public class GBVSyncPresenter extends BaseSyncPresenter {
         String registrationDate = incidentsJsonObject.get(RecordService.DATE_OF_INTERVIEW).getAsString();
 
         if (item != null) {
-            item.setIncidentCaseId(incidentsJsonObject.get(COLUMN_INCIDENT_CASE_ID).getAsString());
             setIncidentProperties(item, incidentsJsonObject);
             item.update();
         } else {


### PR DESCRIPTION
Not all the times we get incident_case_id when downloading incidents, setIncidentCaseId was not necessary because  in next line setIncidentProperties checks if COLUMN_INCIDENT_CASE_ID is present and if so it reads the value